### PR TITLE
Some Layout Modifications

### DIFF
--- a/_layouts/bio.html
+++ b/_layouts/bio.html
@@ -7,7 +7,7 @@
 {% include _head.html %}
 </head>
 
-<body class="home">
+<body class="page">
 
 {% include _browser-upgrade.html %}
 
@@ -29,20 +29,23 @@
 {% endif %}
 
 <div id="main" role="main">
-  <div id="index">
-    <h3><a href="{{ site.url}}/posts/">Recent Posts</a></h3>
-    {% for post in site.posts limit:5 %}
-    <article>
-      {% if post.link %}
-        <h2 class="link-post"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-link"></i></a></h2>
-      {% else %}
-        <h2><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
-        <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>
+  <div class="article-author-side">
+    {% include _author-bio.html %}
+  </div>
+  <article class="bio">
+    <h1>{{ page.title }}</h1>
+    <div class="article-wrap">
+      {{ content }}
+      {% if page.share != false %}
+        <hr />
+        {% include _social-share.html %}
       {% endif %}
-    </article>
-    {% endfor %}
-  </div><!-- /#index -->
-</div><!-- /#main -->
+    </div><!-- /.article-wrap -->
+    {% if site.owner.disqus-shortname and page.comments == true %}
+      <section id="disqus_thread"></section><!-- /#disqus_thread -->
+    {% endif %}
+  </article>
+</div><!-- /#index -->
 
 <div class="footer-wrap">
   <footer>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -29,9 +29,6 @@
 {% endif %}
 
 <div id="main" role="main">
-  <div class="article-author-side">
-    {% include _author-bio.html %}
-  </div>
   <article class="page">
     <h1>{{ page.title }}</h1>
     <div class="article-wrap">

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -226,8 +226,25 @@ $button-size: 1.5rem;
 	h1 {
 		margin-top: 0;
 	}
-	.post,
-	.page {
+        .page {
+	        @include container;
+	        @include grid(12,10);
+	        @include prefix(12,1);
+	        @include suffix(12,1);
+	        margin-bottom: 2em;
+		@media #{$small} {
+		    @include grid(12,10);
+		    @include prefix(12,1);
+		    @include suffix(12,0);
+		}
+		@media #{$large} {
+		    @include grid(12,10);
+		}
+		@media #{$x-large} {
+		    @include grid(12,10);
+		}
+	}
+	.post, .bio {
 		@include container;
 		@include grid(12,10);
 		@include prefix(12,1);
@@ -255,15 +272,15 @@ $button-size: 1.5rem;
 	@include suffix(12,1);
 	margin-bottom: 2em;
 	@media #{$small} {
-		@include grid(12,8);
-		@include prefix(12,0);
+		@include grid(12,10);
+		@include prefix(12,1);
 		@include suffix(12,0);
 	}
 	@media #{$large} {
-		@include grid(12,6);
+		@include grid(12,10);
 	}
 	@media #{$x-large} {
-		@include grid(12,5);
+		@include grid(12,10);
 	}
 	h3 {
 		margin: 0;

--- a/about/jakehschwartz.md
+++ b/about/jakehschwartz.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: bio
 title: "Jake Schwartz"
 date: 2016-04-14 00:00:00 -0700
 author: jakehschwartz

--- a/about/pseudoramble.md
+++ b/about/pseudoramble.md
@@ -1,12 +1,12 @@
 ---
-layout: page
+layout: bio
 title: "Doug Swain"
 date: 2016-04-17 00:00:00 -0500
 author: pseudoramble
 categories: bios
 ---
 
-A short bit about myself: I attended The University of New Hampshire (UNH) where I obtained my BS in Computer Science. And yes, N244 ("The Lounge") is where I spent much of my time. I think the amount of time spend there increased at roughly O(2^n), though it doesn't seem like the program to test that idea has terminated yet. 
+A short bit about myself: I attended The University of New Hampshire (UNH) where I obtained my BS in Computer Science. And yes, N244 ("The Lounge") is where I spent much of my time. I think the amount of time spend there increased at roughly `O(2^n)`, though it doesn't seem like the program to test that idea has terminated yet. 
 
 After UNH, my professional life after has been working as a front-end software developer (along with RESTful services here and there). My main language of use here is Javascript (ES5 initially, but much more ES 6/7 recently) along with Javascript tools like React and Redux. I also dabble in HTML and CSS as I need to.
 


### PR DESCRIPTION
Here are a couple of layout modifications I made. In particular they remove the author sidebar thingy from things that use the 'page' or 'home' layout. The author sidebar thing is still included for the 'post' and 'bio' sections since one might be interested in seeing who wrote the piece.

The changes roughly include:

- Creating a new layout for bios.
- Modifying the page/home layouts to take out the markup for the sidebar.
- Updating the .page class styling so that it's more centered-appearing when the sidebar isn't there. I did this by adjusting the amount of columns it was calculating for the section.

I'm not exactly sure this is what we want, but I thought it might be of interest to check out. I'm open to suggestions.